### PR TITLE
Vimのroleでnameキーに対するvalueがなかったので追記

### DIFF
--- a/ansible/roles/vim/tasks/main.yml
+++ b/ansible/roles/vim/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name:
+- name: Install vim of latest version
   yum:
     name: vim
     state: latest


### PR DESCRIPTION
## 概要
vimのroleを記載しているmain.ymlにおいて、nameキーのvalueがなかったので追記。